### PR TITLE
entrypoint.sh: check if files directory exists and is owned by root

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,14 @@ set -e
 
 TOKEN_DB_PATH="/app/rootfs/data/data/com.apple.android.music/files/mpl_db/kvs.sqlitedb"
 
+if [ ! -d "/app/rootfs/data/data/com.apple.android.music/files" ]; then
+  mkdir -p "/app/rootfs/data/data/com.apple.android.music/files"
+fi
+
+if [ $(stat -c %U "/app/rootfs/data") != "root" ] || [ $(stat -c %G "/app/rootfs/data") != "root" ]; then
+  chown -R root:root "/app/rootfs/data"
+fi
+
 if [ ! -f "$TOKEN_DB_PATH" ]; then
   echo "Login required: account database not found."
   if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then


### PR DESCRIPTION
If the `/app/rootfs/data/data/com.apple.android.music/files` directory is nonexistent or is not owned by root, the wrapper fails to sign in.

This commit changes `entrypoint.sh` to check if the `/app/rootfs/data/data/com.apple.android.music/files` directory exists, and creates it if it does not.

It also checks if the `/app/rootfs/data` directory is owned by root, and changes the owner to root if it isn't.