### PR TITLE
key server: enable R1 content-template hook in MyRelease builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,15 @@ target_link_libraries(main PRIVATE cjson)
 target_link_libraries(main PRIVATE dobby)
 
 set_target_properties(main PROPERTIES
-    # MyRelease intentionally removed: debug build (Dobby hooks + log redirection)
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/rootfs/system/bin"
 )
+
+# Release build: disable curl/log debug hooks. The Dobby R1 key-server hook
+# (content template capture) stays enabled in both modes — Dobby is always linked.
+option(MYRELEASE "Release build (no curl/log debug hooks; R1 key-server hook still enabled)" OFF)
+if(MYRELEASE)
+    target_compile_definitions(main PRIVATE MyRelease)
+endif()
 
 set(SYSTEM_LIB_DIR "${CMAKE_SOURCE_DIR}/rootfs/system/lib64")
 find_library(ANDROIDAPPMUSIC_LIB androidappmusic PATHS ${SYSTEM_LIB_DIR})

--- a/main.c
+++ b/main.c
@@ -18,7 +18,8 @@
  *   捕获, 供纯 Python 离线解密器 (decryption/src/decrypt_tool.py --content-server)
  *   对任意新音轨做完全离线解密。见 decryption/docs/offline-decryption.md。
  *
- * 构建: CMakeLists.txt (NDK clang, debug 构建含 Dobby hook; MyRelease 构建不编译 hook)
+ * 构建: CMakeLists.txt (NDK clang; cmake -DMYRELEASE=ON 切换 Release) — R1 key-server
+ *   hook (Dobby) 两种模式都编译; curl/log debug hook 仅 Debug
  */
 #include <errno.h>
 #include <setjmp.h>
@@ -39,10 +40,8 @@
 #include "import.h"
 #include "cmdline.h"
 #include "cJSON.h"
-#ifndef MyRelease
 #include "dobby.h"
 #include <link.h>
-#endif
 
 static struct shared_ptr apInf;
 static uint8_t leaseMgr[16];
@@ -894,7 +893,6 @@ static void key_json_error(const int connfd, const char *code, const char *msg) 
 }
 
 
-#ifndef MyRelease
 /* =====================================================================
  * content 解密模板捕获 (供 40020 key server 返回)
  * ---------------------------------------------------------------------
@@ -1022,7 +1020,6 @@ static void b64encode(const uint8_t *in, size_t len, char *out) {
     }
     out[o] = 0;
 }
-#endif
 
 /*
  * 40020 key 服务 (HTTP GET): 解析 ?adamId=&uri= 参数。
@@ -1086,7 +1083,6 @@ void handle_key_request(const int connfd) {
     cJSON_AddStringToObject(root, "adamId", adamId);
     cJSON_AddStringToObject(root, "keyUri", uri);
     cJSON_AddStringToObject(root, "contentKey", contentKey);
-#ifndef MyRelease
     {
         uint8_t cap_ctx[0x8000], cap_state[0x2100];
         uint64_t rcx = 0, rax = 0, rdx = 0, r9 = 0, rbp = 0;
@@ -1119,7 +1115,6 @@ void handle_key_request(const int connfd) {
             fprintf(stderr, "[.] key response +ctx template (adamId=%s)\n", adamId);
         }
     }
-#endif
     char *json_body = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (!json_body) { free(contentKey); free(adamId); free(uri); return; }


### PR DESCRIPTION
## What

The 40020 key server's **content decryption template** (`ctx`/`state`/`rcx`/`rax`/`rdx`/`r9`/`rbp`) — the "三件套" the pure-Python offline decryptor (`decryption/src/decrypt_tool.py --content-server`) needs to decrypt any new track fully offline — was gated behind `#ifndef MyRelease`. So `MyRelease` builds started the key server but only returned `contentKey`, and the offline decryptor could not work in Release mode.

## Changes

- **`main.c`** — move the R1 hook (Dobby instrument at libCoreLSKD+0x1d5709) and the `handle_key_request` template-capture block out of the `#ifndef MyRelease` guard so both Debug and Release compile them. `dobby.h`/`<link.h>` become unconditional includes. The curl/log **debug** hooks (`install_hooks` definition + `main()` call) stay `#ifndef MyRelease` — Release keeps system libcurl / SSL verification.
- **`CMakeLists.txt`** — add `option(MYRELEASE ...)` + `target_compile_definitions(main PRIVATE MyRelease)`. Previously the `MyRelease` define was never set, so the Release flag branch (`-Wall -Werror`, no curl, no `-g`) in CMakeLists was dead code; `cmake -DMYRELEASE=ON` now cleanly produces a Release build. Dobby remains unconditionally linked (R1 hook needed in both modes).

## Verification

Built both variants in an isolated worktree (NDK r23b, reused FetchContent cache):

| Mode | R1 hook (content template) | curl/log debug hook | main.c `-Wall -Werror` |
|------|---|---|---|
| Release (`-DMYRELEASE=ON`) | ✓ present | ✗ absent | ✓ no warnings |
| Debug (default) | ✓ present | ✓ present | ✓ |

- Release: `cmake -DMYRELEASE=ON .. && make` → `rootfs/system/bin/main` (329 KB), `grep -c 'R1 hook installed'` = 1, `grep -c 'hooked curl_easy_setopt'` = 0.
- Debug: `cmake .. && make main` → binary contains both R1 hook and curl debug hook strings.

Runtime functional check (needs a valid Apple Music session) not run in this environment:
```bash
./wrapper -L user:pass -H 0.0.0.0
curl -s 'http://127.0.0.1:40020/key?adamId=<adamId>'   # Release should return ctx/state/rcx/rax/rdx/r9/rbp
```

## Notes

- `CLAUDE.md` (untracked in the main checkout, not in this worktree) still says MyRelease = "no Dobby hooks" — should be updated to: curl/log debug hooks disabled, Dobby R1 key-server hook still enabled.
- `subhook` was considered as a Dobby replacement but rejected: it only does function replacement with no `RegisterContext` in the callback, so it cannot capture the instantaneous registers at the R1 entry and continue the original function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)